### PR TITLE
[대시보드] 

### DIFF
--- a/src/main/java/com/codeit/findex/dto/dashboard/response/PeriodType.java
+++ b/src/main/java/com/codeit/findex/dto/dashboard/response/PeriodType.java
@@ -3,5 +3,7 @@ package com.codeit.findex.dto.dashboard.response;
 public enum PeriodType {
   DAILY,
   WEEKLY,
-  MONTHLY
+  MONTHLY,
+  QUARTERLY,
+  YEARLY
 }

--- a/src/main/java/com/codeit/findex/repository/DashboardRepository.java
+++ b/src/main/java/com/codeit/findex/repository/DashboardRepository.java
@@ -86,47 +86,5 @@ public interface DashboardRepository extends JpaRepository<IndexData, Long> {
 
   // ==================================== 지수 성과 분석 랭킹 ====================================
 
-  /**
-   * 모든 IndexInfo에 대해 가장 최신의 IndexData를 한번의 쿼리로 조회합니다. N+1 문제를 해결하기 위해 Native SQL과 ROW_NUMBER를 사용합니다
-   */
-  @Query(
-      value =
-          """
-        WITH RankedData AS (
-            SELECT *,  -- THIS IS THE CRITICAL LINE. It makes all columns available.
-                   ROW_NUMBER() OVER(PARTITION BY index_info_id ORDER BY base_date DESC) as rn
-            FROM index_data
-        )
-        SELECT id, index_info_id, base_date, source_type, market_price,
-               closing_price, high_price, low_price, versus, fluctuation_rate,
-               trading_quantity, trading_price, market_total_amount, enabled,
-               created_at, updated_at
-        FROM RankedData
-        WHERE rn = 1
-      """,
-      nativeQuery = true)
-  List<IndexData> findAllRecentIndexData();
 
-  /**
-   * 모든 IndexInfo에 대해 특정 과거 시점 / 그 이전에 가장 최신인 IndexData를 한번의 쿼리로 조회합니다. 주말이나 공휴일 데이터를 처리하며, N+1문제를
-   * 해결하기 위해 Native SQL과 ROW_NUMBER를 사용합니다.
-   */
-  @Query(
-      value =
-          """
-      WITH RankedData AS (
-          SELECT *,
-              ROW_NUMBER() OVER(PARTITION BY index_info_id ORDER BY base_date DESC) as rn
-          FROM index_data
-          WHERE base_date <= :pastDate
-      )
-      SELECT id, index_info_id, base_date, source_type, market_price,
-                              closing_price, high_price, low_price, versus, fluctuation_rate,
-                              trading_quantity, trading_price, market_total_amount, enabled,
-                              created_at, updated_at -- Select all columns
-      FROM RankedData
-      WHERE rn = 1
-    """,
-      nativeQuery = true)
-  List<IndexData> findAllPastIndexData(@Param("pastDate") LocalDate pastDate);
 }

--- a/src/main/java/com/codeit/findex/repository/DashboardRepository.java
+++ b/src/main/java/com/codeit/findex/repository/DashboardRepository.java
@@ -22,6 +22,10 @@ public interface DashboardRepository extends JpaRepository<IndexData, Long> {
       long indexInfoId, LocalDate baseDate);
 
   //  =====================
+
+  List<IndexData> findByIndexInfoIdInAndBaseDateIn(List<Long> indexInfoIds, List<LocalDate> baseDates);
+
+
   /** 리스트에 있는 indexInfoId당 특정 indexInfoId에 해당하는 가장 최신 IndexData를 조회합니다. */
   @Query(
       "SELECT d FROM IndexData d WHERE d.indexInfo.id IN :indexInfoIds AND d.baseDate = "

--- a/src/main/java/com/codeit/findex/repository/DashboardRepository.java
+++ b/src/main/java/com/codeit/findex/repository/DashboardRepository.java
@@ -10,20 +10,11 @@ import org.springframework.data.repository.query.Param;
 
 public interface DashboardRepository extends JpaRepository<IndexData, Long> {
 
-  // ==================================== 즐겨찾기 지수 현황 요약 ====================================
-  /** 특정 indexInfoId에 해당하는 가장 최신 IndexData를 조회합니다. */
+  // 특정 indexInfoId에 해당하는 가장 최신 IndexData를 조회
   Optional<IndexData> findTopByIndexInfoIdOrderByBaseDateDesc(long indexInfoId);
 
-  /**
-   * 특정 날짜(targetDate) 혹은 그 이전의 가장 최신 IndexData를 조회합니다. 주말이나 공휴일처럼 특정 날짜에 IndexData가 없는 경우를 처리하는 데
-   * 핵심적인 역할을 합니다.
-   */
-  Optional<IndexData> findTopByIndexInfoIdAndBaseDateLessThanEqualOrderByBaseDateDesc(
-      long indexInfoId, LocalDate baseDate);
 
-  // ========================== (claude)
-
-  // Get most recent data for each index (instead of exact date)
+  // 각 IndexInfo의 가장 최신 IndexData를 가져옴
   @Query("""
         SELECT id1 FROM IndexData id1 
         WHERE id1.indexInfo.id IN :indexInfoIds 
@@ -38,7 +29,7 @@ public interface DashboardRepository extends JpaRepository<IndexData, Long> {
       @Param("indexInfoIds") List<Long> indexInfoIds,
       @Param("maxDate") LocalDate maxDate);
 
-  // Get closest past data for comparison
+  // 각 IndexInfo의 targetDate과 가장 가까운 최신 IndexData를 가져옴
   @Query("""
         SELECT id1 FROM IndexData id1 
         WHERE id1.indexInfo.id IN :indexInfoIds 
@@ -55,36 +46,10 @@ public interface DashboardRepository extends JpaRepository<IndexData, Long> {
       @Param("targetDate") LocalDate targetDate,
       @Param("minDate") LocalDate minDate);
 
-  //  =====================
 
-  List<IndexData> findByIndexInfoIdInAndBaseDateIn(List<Long> indexInfoIds, List<LocalDate> baseDates);
-
-
-  /** 리스트에 있는 indexInfoId당 특정 indexInfoId에 해당하는 가장 최신 IndexData를 조회합니다. */
-  @Query(
-      "SELECT d FROM IndexData d WHERE d.indexInfo.id IN :indexInfoIds AND d.baseDate = "
-          + "(SELECT MAX(d2.baseDate) FROM IndexData d2 WHERE d2.indexInfo.id = d.indexInfo.id)")
-  List<IndexData> findRecentByIndexInfoIds(@Param("indexInfoIds") List<Long> indexInfoIds);
-
-  /**
-   * For a given list of IndexInfo IDs, finds all their content points that occurred on or before a
-   * specified date. This is used to fetch a superset of all potential comparison content in a single
-   * query.
-   */
-  @Query(
-      "SELECT d FROM IndexData d "
-          + "WHERE d.indexInfo.id IN :indexInfoIds AND d.baseDate <= :maxDate")
-  List<IndexData> findPastByIndexInfoIds(
-      @Param("indexInfoIds") List<Long> indexInfoIds, @Param("maxDate") LocalDate maxDate);
-
-  // ================================================ 차트
-  // ================================================
-  /** 지정된 지수 정보 ID와 기준일자 범위에 해당하는 지수 데이터를 기준일자 오름차순으로 조회합니다. */
+  // 지정된 지수 정보 ID와 기준일자 범위에 해당하는 지수 데이터를 기준일자 오름차순으로 조회
   // Asc - oldest to newest (e.g., Jan 1, Jan 2, Jan 3, ...).
   List<IndexData> findByIndexInfoIdAndBaseDateBetweenOrderByBaseDateAsc(
       long indexInfoId, LocalDate startDate, LocalDate endDate);
-
-  // ==================================== 지수 성과 분석 랭킹 ====================================
-
 
 }

--- a/src/main/java/com/codeit/findex/repository/DashboardRepository.java
+++ b/src/main/java/com/codeit/findex/repository/DashboardRepository.java
@@ -21,6 +21,40 @@ public interface DashboardRepository extends JpaRepository<IndexData, Long> {
   Optional<IndexData> findTopByIndexInfoIdAndBaseDateLessThanEqualOrderByBaseDateDesc(
       long indexInfoId, LocalDate baseDate);
 
+  // ========================== (claude)
+
+  // Get most recent data for each index (instead of exact date)
+  @Query("""
+        SELECT id1 FROM IndexData id1 
+        WHERE id1.indexInfo.id IN :indexInfoIds 
+        AND id1.baseDate = (
+            SELECT MAX(id2.baseDate) 
+            FROM IndexData id2 
+            WHERE id2.indexInfo.id = id1.indexInfo.id 
+            AND id2.baseDate <= :maxDate
+        )
+        """)
+  List<IndexData> findMostRecentByIndexInfoIdsAndMaxDate(
+      @Param("indexInfoIds") List<Long> indexInfoIds,
+      @Param("maxDate") LocalDate maxDate);
+
+  // Get closest past data for comparison
+  @Query("""
+        SELECT id1 FROM IndexData id1 
+        WHERE id1.indexInfo.id IN :indexInfoIds 
+        AND id1.baseDate = (
+            SELECT MAX(id2.baseDate) 
+            FROM IndexData id2 
+            WHERE id2.indexInfo.id = id1.indexInfo.id 
+            AND id2.baseDate <= :targetDate 
+            AND id2.baseDate >= :minDate
+        )
+        """)
+  List<IndexData> findClosestPastByIndexInfoIdsAndTargetDate(
+      @Param("indexInfoIds") List<Long> indexInfoIds,
+      @Param("targetDate") LocalDate targetDate,
+      @Param("minDate") LocalDate minDate);
+
   //  =====================
 
   List<IndexData> findByIndexInfoIdInAndBaseDateIn(List<Long> indexInfoIds, List<LocalDate> baseDates);

--- a/src/main/java/com/codeit/findex/service/ExternalApiService.java
+++ b/src/main/java/com/codeit/findex/service/ExternalApiService.java
@@ -34,7 +34,7 @@ public class ExternalApiService {
                     .path("/getStockMarketIndex")
                     .queryParam("serviceKey", apiKey)
                     .queryParam("resultType", "json")
-                    .queryParam("numOfRows", 50)
+                    .queryParam("numOfRows", 10000)
                     .build())
         .accept(MediaType.APPLICATION_JSON)
         .retrieve()

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -7,7 +7,8 @@ spring:
   jpa:
     hibernate:
       ddl-auto: create # 운영 배포 시엔 none 또는 validate 권장
-    show-sql: true
+#    show-sql: true
+    show-sql: false
     database-platform: org.hibernate.dialect.PostgreSQLDialect
     properties:
       hibernate:
@@ -29,9 +30,10 @@ batch:
 
 logging:
   level:
-    org.springframework.data.jpa.domain.support.AuditingEntityListener : DEBUG
-    org.hibernate.SQL: debug
-    org.hibernate.orm.jdbc.bind: trace
+    org.hibernate: INFO
+#    org.springframework.data.jpa.domain.support.AuditingEntityListener : DEBUG
+#    org.hibernate.SQL: debug
+#    org.hibernate.orm.jdbc.bind: trace
 
 external:
   api:


### PR DESCRIPTION
- [x] 주요 지수의 getFavPerformanceDto 메서드 로직 수정
  - 현재 + 과거 시점 데이터 조회 -> 2번의 쿼리로 N + 1 문제 해결
    - 현재 데이터: 즐겨찾기 ID 리스트를 기반으로, 각 지표의 가장 최신 IndexData를 한 번의 쿼리로 모두 조회함
    - 과거 데이터: periodType에 따라 계산된 과거 날짜를 기준으로, 각 지표의 가장 근접한 IndexData를 또 다른 한 번의 쿼리로 모두 조회함
  - 휴일이나 주말이 있어서 정확한 날짜로 가져오는것이 아니라 날짜에 맞춰서 가장 가까운 날짜의 IndexData를 사용함
