### PR TITLE
bugfix: [지수 관리] deleteIndexInfo 로직 수정

### DIFF
--- a/src/main/java/com/codeit/findex/repository/IntegrationRepository.java
+++ b/src/main/java/com/codeit/findex/repository/IntegrationRepository.java
@@ -7,6 +7,8 @@ import com.codeit.findex.entityEnum.JobType;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
+
+import jakarta.transaction.Transactional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -41,4 +43,6 @@ WHERE i.indexInfo.id = :indexInfoId
       @Param("worker") String worker,
       @Param("afterTime") LocalDateTime afterTime);
 
+  @Transactional
+  void deleteAllByIndexInfoId(Long indexInfoId);
 }

--- a/src/main/java/com/codeit/findex/repository/IntegrationRepository.java
+++ b/src/main/java/com/codeit/findex/repository/IntegrationRepository.java
@@ -10,6 +10,7 @@ import java.util.Optional;
 
 import jakarta.transaction.Transactional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -43,6 +44,8 @@ WHERE i.indexInfo.id = :indexInfoId
       @Param("worker") String worker,
       @Param("afterTime") LocalDateTime afterTime);
 
-  @Transactional
-  void deleteAllByIndexInfoId(Long indexInfoId);
+  @Modifying
+  @Query("DELETE FROM Integration i WHERE i.indexInfo.id = :indexInfoId")
+  void deleteAllByIndexInfoId(@Param("indexInfoId") Long indexInfoId);
 }
+

--- a/src/main/java/com/codeit/findex/service/indexinfo/basic/BasicIndexInfoService.java
+++ b/src/main/java/com/codeit/findex/service/indexinfo/basic/BasicIndexInfoService.java
@@ -8,10 +8,12 @@ import com.codeit.findex.dto.indexInfo.response.IndexInfoDto;
 import com.codeit.findex.dto.indexInfo.response.IndexInfoSummaryDto;
 import com.codeit.findex.entity.IndexData;
 import com.codeit.findex.entity.IndexInfo;
+import com.codeit.findex.entityEnum.SourceType;
 import com.codeit.findex.mapper.IndexInfoMapper;
 import com.codeit.findex.repository.AutoSyncRepository;
 import com.codeit.findex.repository.IndexDataRepository;
 import com.codeit.findex.repository.IndexInfoRepository;
+import com.codeit.findex.repository.IntegrationRepository;
 import com.codeit.findex.service.indexinfo.IndexInfoService;
 import jakarta.transaction.Transactional;
 import java.util.List;
@@ -30,6 +32,7 @@ public class BasicIndexInfoService implements IndexInfoService {
   private final IndexInfoMapper indexInfoMapper;
   private final IndexDataRepository indexDataRepository;
   private final AutoSyncRepository autoSyncRepository;
+  private final IntegrationRepository integrationRepository;
 
   @Transactional
   @Override
@@ -187,7 +190,15 @@ public class BasicIndexInfoService implements IndexInfoService {
         indexInfoRepository
             .findById(id)
             .orElseThrow(
-                () -> new IllegalArgumentException("Index info with ID" + id + "not found"));
+                () -> new IllegalArgumentException("Index info with" + id + "not found"));
+    SourceType sourceType = indexInfo.getSourceType();
+
+    if (sourceType == SourceType.OPEN_API) {
+      autoSyncRepository.deleteById(id);
+    }
+
+    integrationRepository.deleteAllByIndexInfoId(id);
+
     List<IndexData> indexDataList = indexDataRepository.findAllByIndexInfoId(id);
     if (!indexDataList.isEmpty()) {
       indexDataRepository.deleteAll(indexDataList);


### PR DESCRIPTION
# 주 변경사항

- [x] 지수 정보 삭제 시 Open Api 로 연동된 정보는 삭제되지 않는 문제 해결
 - [x] integration 정보 삭제하는 코드 추가
 - [x] integrationRepository에 @Modifying, 쿼리문 활용하여 deleteAllByIndexInfoId 추가